### PR TITLE
[ADD] Auto-calculate product field.

### DIFF
--- a/auto_calculate_price/__init__.py
+++ b/auto_calculate_price/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/auto_calculate_price/__manifest__.py
+++ b/auto_calculate_price/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+{
+    'name': 'Auto-calculate field.',
+    'summary': """Module to auto-calculate the price of a sale based on a condition.""",
+    'description': """
+        Sales Price - This field uses the pair per case and price per pair to calculate the Sales price (Pair per price X Price per Pair). 
+        If nothing is entered in the Pair per Case and Price per Pair, the Sales price should be editable. 
+        If something is entered in Pair per Price or Price per Pair, the field should be read-only. 
+    """,
+    'author': 'Odoo',
+    'website': 'https://www.odoo.com',
+    'category': 'Training',
+    'version': '15.0.1.0.0',
+    'depends': ['product'],
+    'data': [
+        'views/product_template_views_inherit.xml',
+    ],
+    'license': 'OPL-1',
+}

--- a/auto_calculate_price/models/__init__.py
+++ b/auto_calculate_price/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import product_template

--- a/auto_calculate_price/models/product_template.py
+++ b/auto_calculate_price/models/product_template.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+    _description = 'Product Template'
+
+    pair_per_case = fields.Integer(string='Pair per Case')
+    price_per_pair = fields.Monetary(string='Price per Pair')
+
+    list_price = fields.Float(compute='_compute_list_price',
+                              inverse='_inverse_list_price',
+                              store=True,
+                              states={'editable': [('readonly', False)], 'read_only': [('readonly', True)]})
+
+    state = fields.Selection([('editable', 'Editable'), ('read_only',
+                             'Read Only')], 'Status', copy=True, default='editable', readonly=True)
+
+    @api.depends('pair_per_case', 'price_per_pair')
+    def _compute_list_price(self):
+        for product in self:
+            if product.pair_per_case or product.price_per_pair:
+                product.list_price = product.pair_per_case * product.price_per_pair
+                product.state = 'read_only'
+            else:
+                product.state = 'editable'
+
+    def _inverse_list_price(self):
+        for product in self:
+            if not product.pair_per_case:
+                product.pair_per_case = 0
+            if not product.price_per_pair:
+                product.price_per_pair = 0

--- a/auto_calculate_price/models/product_template.py
+++ b/auto_calculate_price/models/product_template.py
@@ -12,20 +12,13 @@ class ProductTemplate(models.Model):
 
     list_price = fields.Float(compute='_compute_list_price',
                               inverse='_inverse_list_price',
-                              store=True,
-                              states={'editable': [('readonly', False)], 'read_only': [('readonly', True)]})
-
-    state = fields.Selection([('editable', 'Editable'), ('read_only',
-                             'Read Only')], 'Status', copy=True, default='editable', readonly=True)
+                              store=True)
 
     @api.depends('pair_per_case', 'price_per_pair')
     def _compute_list_price(self):
         for product in self:
             if product.pair_per_case or product.price_per_pair:
                 product.list_price = product.pair_per_case * product.price_per_pair
-                product.state = 'read_only'
-            else:
-                product.state = 'editable'
 
     def _inverse_list_price(self):
         for product in self:

--- a/auto_calculate_price/views/product_template_views_inherit.xml
+++ b/auto_calculate_price/views/product_template_views_inherit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record model="ir.ui.view" id="product_template_only_form_view">
+            <field name="name">product.template.product.form.inherit..inherit.auto.calculate.price</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref='product.product_template_only_form_view'/>
+            <field name="arch" type="xml">
+                <field name="categ_id" position="before">
+                    <field name="pair_per_case" />
+                    <field name="price_per_pair" /> 
+                    <field name="state" invisible="1"/> 
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/auto_calculate_price/views/product_template_views_inherit.xml
+++ b/auto_calculate_price/views/product_template_views_inherit.xml
@@ -9,7 +9,16 @@
                 <field name="categ_id" position="before">
                     <field name="pair_per_case" />
                     <field name="price_per_pair" /> 
-                    <field name="state" invisible="1"/> 
+                </field>
+                <field name='list_price' position='attributes'>
+                    <attribute name="attrs">
+                        { 
+                        'readonly': [
+                            ('pair_per_case', '!=', 0),
+                            ('price_per_pair', '!=', 0)
+                        ]
+                        }
+                    </attribute>
                 </field>
             </field>
         </record>


### PR DESCRIPTION


### Description

This module auto-calculates a field based on two created fields. If both of them have values, the calculated field is equal to the multiplication of the two and this field should be readonly == True.

This module inherits from product.template and filters the condition completely in the back-end.

Link to task: [#2874759](https://www.odoo.com/web#id=2874759&menu_id=4720&cids=17&action=333&active_id=4533&model=project.task&view_type=form)

### All Submissions:

* [ ] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [ ] I have used pre-commit
* [ ] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [ ] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [ ] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 
