### PR TITLE
[ADD] inherit from purchase.order and create action_cron_auto_confirm…

### DIFF
--- a/odoo_schedule/__init__.py
+++ b/odoo_schedule/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/odoo_schedule/__manifest__.py
+++ b/odoo_schedule/__manifest__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Odoo Schedule',
+    'sumary': 'Mindesa : Scheduled Action to Confirm RFQs',
+    'description': """
+        odoo schedule helps to schedule the action to confirm RFQs
+    """,
+    'author': 'EduardoCedillo(eacm)',
+    'category': 'Purchase',
+    'version': '14.0.1.0.0',
+    'depends': ['sale'],
+    'license': 'OPL-1',
+    'data': [
+        'data/cron.xml',
+    ],
+}

--- a/odoo_schedule/data/cron.xml
+++ b/odoo_schedule/data/cron.xml
@@ -1,0 +1,11 @@
+<odoo>
+    <record id="ir_cron_auto_confirm_rfqs" model="ir.cron">
+        <field name="name">Scheduled Action to confirm RFQs : Confirm RFQs</field>
+        <field name="model_id" ref="model_purchase_order"/>
+        <field name="state">code</field>
+        <field name="code">model.action_cron_auto_confirm_rfqs()</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+    </record>
+</odoo>

--- a/odoo_schedule/models/__init__.py
+++ b/odoo_schedule/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import purchase_order

--- a/odoo_schedule/models/purchase_order.py
+++ b/odoo_schedule/models/purchase_order.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models, _
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    def action_cron_auto_confirm_rfqs(self):
+        """
+        This method is used to confirm RFQs automatically but only from Mindesa SAPI de CV
+        """
+        for order in self.env['purchase.order'].search([('state', '=', 'draft'),
+         ('partner_id.id', '=', self.env.ref('base.main_partner').id),
+          ('user_id.id', '=', self.env.ref('base.user_admin').id)]):
+            order.button_confirm()


### PR DESCRIPTION
…_rfqs to confirm RFQs only from X company id and X purchase representative, create the cron task to run every day once

### Description

*-inherit from purchase.order
create a function to work as cron task(named = action_cron_auto_confirm_rfqs) that will confirm the RFQs
create a cron task that uses action_cron_auto_confirm_rfqs and runs every day one time*

Link to task: [#2874721](https://www.odoo.com/web#id=2874721&cids=17&menu_id=4720&action=4665&active_id=2874696&model=project.task&view_type=form)

