### PR TITLE
[ADD] Module to create product specific lots

### DIFF
--- a/product_specific_lots/__init__.py
+++ b/product_specific_lots/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/product_specific_lots/__manifest__.py
+++ b/product_specific_lots/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+{
+    'name': 'Product Specific Lots',
+    'summary': """Module to create specific lot numbers related to the product.""",
+    'description': """
+        This module lets the user create a prefix based on nomenclature related to the product.
+        Once this prefix is created, in the manufacturing process we should be able to add the lot number
+            with the prefix created in the product.template form.
+    """,
+    'author': 'Odoo PS',
+    'website': 'https://www.odoo.com',
+    'category': 'Training',
+    'version': '14.0.1.0.0',
+    'depends': ['product', 'mrp', 'stock'],
+    'data': [
+        'views/product_template_views_inherit.xml',
+    ],
+    'license': 'OPL-1',
+}

--- a/product_specific_lots/__manifest__.py
+++ b/product_specific_lots/__manifest__.py
@@ -12,7 +12,7 @@
     'website': 'https://www.odoo.com',
     'category': 'Training',
     'version': '14.0.1.0.0',
-    'depends': ['product', 'mrp', 'stock'],
+    'depends': ['product', 'mrp'],
     'data': [
         'views/product_template_views_inherit.xml',
     ],

--- a/product_specific_lots/models/__init__.py
+++ b/product_specific_lots/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import product_template, mrp_production

--- a/product_specific_lots/models/mrp_production.py
+++ b/product_specific_lots/models/mrp_production.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from odoo import models, fields, api
+from odoo import models
 
 
 class MrpProduction(models.Model):

--- a/product_specific_lots/models/mrp_production.py
+++ b/product_specific_lots/models/mrp_production.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api
+
+
+class MrpProduction(models.Model):
+    _inherit = 'mrp.production'
+
+    def action_generate_serial(self):
+        self.ensure_one()
+        if self.product_id.lot_prefix:
+            last_serial = self.env['stock.production.lot'].search(
+                [('company_id', '=', self.company_id.id),
+                 ('product_id', '=', self.product_id.id)],
+                limit=1, order='id DESC')
+            if last_serial:
+                self.lot_producing_id = self.env['stock.production.lot'].create({
+                    'product_id': self.product_id.id,
+                    'company_id': self.company_id.id,
+                    'name': int(last_serial.name) + 1
+                })
+            else:
+                self.lot_producing_id = self.env['stock.production.lot'].create({
+                    'product_id': self.product_id.id,
+                    'company_id': self.company_id.id,
+                    'name': int(str(self.product_id.lot_prefix) + '001')
+                })
+        else:
+            self.lot_producing_id = self.env['stock.production.lot'].create({
+                'product_id': self.product_id.id,
+                'company_id': self.company_id.id
+            })
+        if self.move_finished_ids.filtered(lambda m: m.product_id == self.product_id).move_line_ids:
+            self.move_finished_ids.filtered(
+                lambda m: m.product_id == self.product_id).move_line_ids.lot_id = self.lot_producing_id
+        if self.product_id.tracking == 'serial':
+            self._set_qty_producing()

--- a/product_specific_lots/models/product_template.py
+++ b/product_specific_lots/models/product_template.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    lot_prefix = fields.Char(string='Lot Number Prefix')

--- a/product_specific_lots/views/product_template_views_inherit.xml
+++ b/product_specific_lots/views/product_template_views_inherit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record model="ir.ui.view" id="product_template_only_form_view">
+            <field name="name">product.template.product.form.inherit.product.specific.lots</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref='product.product_template_only_form_view'/>
+            <field name="arch" type="xml">
+                <field name="barcode" position="after">
+                    <field name="lot_prefix" />
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION

### Description

This module adds a lot prefix that the user must define in the product.template form.
At the end of the mrp, the lot should be generated based on the prefix of the product and the last lot number of each product.


Link to task: [#2874739](https://www.odoo.com/web#id=2874739&menu_id=4720&cids=17&action=333&active_id=4533&model=project.task&view_type=form)

### All Submissions:

* [ ] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [ ] I have used pre-commit
* [ ] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [ ] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [ ] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 
