### PR TITLE
[ADD] Module to create job number and plant code

### DIFF
--- a/industrial_kiln/__init__.py
+++ b/industrial_kiln/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/industrial_kiln/__manifest__.py
+++ b/industrial_kiln/__manifest__.py
@@ -1,0 +1,22 @@
+{
+    'name': 'Industrial Kiln & Dryer Group : Job number, Plant code',
+    'summary': """Module to create two custom fields and generate them automatically.""",
+    'description': """
+        There are two fields that need to be created. 
+        The first one is Job Number and it belongs in sale.order:
+            Job Number is concatenated out of three different fields: 
+                -Prefix (selection field).
+                -Sequence: predefined sequence that we can specify and edit if required (starts with 13500, eg. 13500, next job number is 13501 and etc)
+                -Suffix (selection field).
+    """,
+    'author': 'Odoo PS',
+    'website': 'https://www.odoo.com',
+    'category': 'Training',
+    'version': '14.0.1.0.0',
+    'depends': ['sale'],
+    'data': [
+        'views/sale_order_views_inherit.xml',
+        'views/res_partner_views_inherit.xml'
+    ],
+    'license': 'OPL-1',
+}

--- a/industrial_kiln/__manifest__.py
+++ b/industrial_kiln/__manifest__.py
@@ -13,10 +13,12 @@
     'website': 'https://www.odoo.com',
     'category': 'Training',
     'version': '14.0.1.0.0',
-    'depends': ['sale'],
+    'depends': [
+        'sale',
+    ],
     'data': [
         'views/sale_order_views_inherit.xml',
-        'views/res_partner_views_inherit.xml'
+        'views/res_partner_views_inherit.xml',
     ],
     'license': 'OPL-1',
 }

--- a/industrial_kiln/models/__init__.py
+++ b/industrial_kiln/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order, res_partner

--- a/industrial_kiln/models/__init__.py
+++ b/industrial_kiln/models/__init__.py
@@ -1,1 +1,2 @@
-from . import sale_order, res_partner
+from . import sale_order
+from . import res_partner

--- a/industrial_kiln/models/res_partner.py
+++ b/industrial_kiln/models/res_partner.py
@@ -3,52 +3,61 @@ import re
 from odoo import models, fields, api, _
 
 
-class ResPartner(models.Model):
+class Partner(models.Model):
     _inherit = 'res.partner'
 
     plant_code = fields.Char(string='Plant Code',
-                             compute='_compute_plant_code',
-                             readonly=True,
-                             store=True)
+                             compute='_compute_plant_code')
 
-    has_confirmed_SO = fields.Boolean(string='Has a confirmed SO.',
-                                      compute='_compute_has_confirmed_SO',
-                                      default=False)
+    has_confirmed_SO = fields.Boolean(string='Has a confirmed SO.')
 
     plant_prefix = fields.Char(string='Plant Code Prefix')
 
-    def _compute_has_confirmed_SO(self):
-        self.ensure_one()
-        if not self.has_confirmed_SO:
-            if self.env['sale.order'].search([('state', '=', 'sale'), ('partner_id', '=', self.id)]):
-                self.has_confirmed_SO = True
-                self._compute_plant_code()
+    plant_code_sequence_number = fields.Char(string="Sequence for plant code")
 
     @api.depends('has_confirmed_SO')
     def _compute_plant_code(self):
-        if not self.plant_code:
-            if self.has_confirmed_SO:
-                name = self.name
-                name = re.sub('[^A-Za-z0-9]+', '', name)
-                self.plant_prefix = name.upper()[0:3]
-                self._create_plant_code_sequence()
-                sequence_number = str(
-                    self.env['ir.sequence'].next_by_code(self.plant_prefix))
-                self.plant_code = self.plant_prefix + \
-                    sequence_number[3:6] + '-' + sequence_number[6:]
-        else:
-            self.plant_code = self.plant_code
+        for partner in self:
+            if not partner.plant_code and partner.has_confirmed_SO:
+                partner.plant_code = partner.plant_prefix + partner.plant_code_sequence_number
+            else:
+                partner.plant_code = partner.plant_code
 
     @api.model
-    def _create_plant_code_sequence(self):
+    def create(self, vals_list):
+        partners = super(Partner, self).create(vals_list)
+        return partners
+
+    @api.model
+    def _create_plant_code_sequence(self, plant_prefix):
         IrSequence = self.env['ir.sequence']
-        if IrSequence.search([('code', '=', self.plant_prefix)]):
+        if IrSequence.search([('code', '=', plant_prefix)]):
             return
         return IrSequence.sudo().create({
-            'name': _("Plant Code Sequence {}".format(self.plant_prefix)),
-            'code': self.plant_prefix,
-            'prefix': self.plant_prefix,
+            'name': _("Plant Code Sequence {}".format(plant_prefix)),
+            'code': plant_prefix,
+            'prefix': plant_prefix,
             'number_next': 101,
             'use_date_range': False,
             'padding': 5
         })
+
+    def prepare_plant_code_data(self):
+        if self.is_company:
+            name = self.name
+        else:
+            if self.parent_id:
+                name = self.parent_id.name
+            else:
+                name = self.name
+        name = re.sub('[^A-Za-z0-9]+', '', name)
+        if len(name) >= 3:
+            plant_prefix = name.upper()[0:3]
+        else:
+            plant_prefix = name
+        self._create_plant_code_sequence(plant_prefix)
+        sequence_number = str(
+            self.env['ir.sequence'].next_by_code(plant_prefix))
+        self.plant_prefix = plant_prefix
+        self.plant_code_sequence_number = sequence_number[3:6] + \
+            '-' + sequence_number[6:]

--- a/industrial_kiln/models/res_partner.py
+++ b/industrial_kiln/models/res_partner.py
@@ -1,0 +1,54 @@
+import re
+
+from odoo import models, fields, api, _
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    plant_code = fields.Char(string='Plant Code',
+                             compute='_compute_plant_code',
+                             readonly=True,
+                             store=True)
+
+    has_confirmed_SO = fields.Boolean(string='Has a confirmed SO.',
+                                      compute='_compute_has_confirmed_SO',
+                                      default=False)
+
+    plant_prefix = fields.Char(string='Plant Code Prefix')
+
+    def _compute_has_confirmed_SO(self):
+        self.ensure_one()
+        if not self.has_confirmed_SO:
+            if self.env['sale.order'].search([('state', '=', 'sale'), ('partner_id', '=', self.id)]):
+                self.has_confirmed_SO = True
+                self._compute_plant_code()
+
+    @api.depends('has_confirmed_SO')
+    def _compute_plant_code(self):
+        if not self.plant_code:
+            if self.has_confirmed_SO:
+                name = self.name
+                name = re.sub('[^A-Za-z0-9]+', '', name)
+                self.plant_prefix = name.upper()[0:3]
+                self._create_plant_code_sequence()
+                sequence_number = str(
+                    self.env['ir.sequence'].next_by_code(self.plant_prefix))
+                self.plant_code = self.plant_prefix + \
+                    sequence_number[3:6] + '-' + sequence_number[6:]
+        else:
+            self.plant_code = self.plant_code
+
+    @api.model
+    def _create_plant_code_sequence(self):
+        IrSequence = self.env['ir.sequence']
+        if IrSequence.search([('code', '=', self.plant_prefix)]):
+            return
+        return IrSequence.sudo().create({
+            'name': _("Plant Code Sequence {}".format(self.plant_prefix)),
+            'code': self.plant_prefix,
+            'prefix': self.plant_prefix,
+            'number_next': 101,
+            'use_date_range': False,
+            'padding': 5
+        })

--- a/industrial_kiln/models/sale_order.py
+++ b/industrial_kiln/models/sale_order.py
@@ -5,15 +5,41 @@ class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
     job_number_prefix = fields.Selection(
-        [('01', '01'), ('02', '02'), ('03', '03')], copy=False, default='01')
+        [('01', '01'), ('02', '02'), ('03', '03')], copy=False, required=True)
 
     job_number_sufix = fields.Selection(
-        [('01', '01'), ('02', '02'), ('03', '03')], copy=False, default='01')
+        [('01', '01'), ('02', '02'), ('03', '03')], copy=False, required=True)
 
-    job_sequence = fields.Integer(string="Job Sequence")
+    job_sequence = fields.Integer(string="Job Sequence",
+                                  compute='_compute_job_sequence',
+                                  store=True)
 
     job_number = fields.Char(
         compute='_compute_job_number', string='Job Number')
+
+    @api.depends('job_number_prefix')
+    def _compute_job_sequence(self):
+        for sale_order in self:
+            if sale_order.job_sequence == 0:
+                if sale_order.name != _('New'):
+                    sale_order.job_sequence = self.env['ir.sequence'].next_by_code(
+                        'sale.order.job.number') or 23500
+                else:
+                    sale_order.job_sequence = 0
+            else:
+                sale_order.job_sequence = sale_order.job_sequence
+
+    @api.depends('job_number_prefix', 'job_number_sufix', 'job_sequence')
+    def _compute_job_number(self):
+        for sale_order in self:
+            sale_order.job_number = str(sale_order.job_number_prefix) + str(
+                sale_order.job_sequence) + str(sale_order.job_number_sufix)
+
+    @api.model
+    def create(self, vals):
+        res = super(SaleOrder, self).create(vals)
+        self._create_job_number_sequence()
+        return res
 
     @api.model
     def _create_job_number_sequence(self):
@@ -28,39 +54,9 @@ class SaleOrder(models.Model):
             'use_date_range': False,
         })
 
-    @api.model
-    def create(self, vals):
-        self._create_job_number_sequence()
-        if 'company_id' in vals:
-            self = self.with_company(vals['company_id'])
-        if vals.get('name', _('New')) == _('New'):
-            seq_date = None
-            if 'date_order' in vals:
-                seq_date = fields.Datetime.context_timestamp(
-                    self, fields.Datetime.to_datetime(vals['date_order']))
-            vals['name'] = self.env['ir.sequence'].next_by_code(
-                'sale.order', sequence_date=seq_date) or _('New')
-        vals['job_sequence'] = self.env['ir.sequence'].next_by_code(
-            'sale.order.job.number') or 23500
-
-        # Makes sure partner_invoice_id', 'partner_shipping_id' and 'pricelist_id' are defined
-        if any(f not in vals for f in ['partner_invoice_id', 'partner_shipping_id', 'pricelist_id']):
-            partner = self.env['res.partner'].browse(vals.get('partner_id'))
-            addr = partner.address_get(['delivery', 'invoice'])
-            vals['partner_invoice_id'] = vals.setdefault(
-                'partner_invoice_id', addr['invoice'])
-            vals['partner_shipping_id'] = vals.setdefault(
-                'partner_shipping_id', addr['delivery'])
-            vals['pricelist_id'] = vals.setdefault(
-                'pricelist_id', partner.property_product_pricelist.id)
-        result = super(SaleOrder, self).create(vals)
-        return result
-
-    @api.depends('job_number_prefix', 'job_number_sufix', 'job_sequence')
-    def _compute_job_number(self):
-        for sale_order in self:
-            if not sale_order.job_sequence or sale_order.job_sequence == 0:
-                sale_order.job_sequence = self.env['ir.sequence'].next_by_code(
-                    'sale.order.job.number') or 23500
-            sale_order.job_number = str(sale_order.job_number_prefix) + str(
-                sale_order.job_sequence) + str(sale_order.job_number_sufix)
+    def action_confirm(self):
+        res = super(SaleOrder, self).action_confirm()
+        if not self.partner_id.has_confirmed_SO:
+            self.partner_id.prepare_plant_code_data()
+            self.partner_id.has_confirmed_SO = True
+        return res

--- a/industrial_kiln/models/sale_order.py
+++ b/industrial_kiln/models/sale_order.py
@@ -1,0 +1,66 @@
+from odoo import models, fields, api, _
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    job_number_prefix = fields.Selection(
+        [('01', '01'), ('02', '02'), ('03', '03')], copy=False, default='01')
+
+    job_number_sufix = fields.Selection(
+        [('01', '01'), ('02', '02'), ('03', '03')], copy=False, default='01')
+
+    job_sequence = fields.Integer(string="Job Sequence")
+
+    job_number = fields.Char(
+        compute='_compute_job_number', string='Job Number')
+
+    @api.model
+    def _create_job_number_sequence(self):
+        IrSequence = self.env['ir.sequence']
+        if IrSequence.search([('code', '=', 'sale.order.job.number')]):
+            return
+        return IrSequence.sudo().create({
+            'name': _("Job Number Sequence"),
+            'code': 'sale.order.job.number',
+            'number_next': 13500,
+            'number_increment': 1,
+            'use_date_range': False,
+        })
+
+    @api.model
+    def create(self, vals):
+        self._create_job_number_sequence()
+        if 'company_id' in vals:
+            self = self.with_company(vals['company_id'])
+        if vals.get('name', _('New')) == _('New'):
+            seq_date = None
+            if 'date_order' in vals:
+                seq_date = fields.Datetime.context_timestamp(
+                    self, fields.Datetime.to_datetime(vals['date_order']))
+            vals['name'] = self.env['ir.sequence'].next_by_code(
+                'sale.order', sequence_date=seq_date) or _('New')
+        vals['job_sequence'] = self.env['ir.sequence'].next_by_code(
+            'sale.order.job.number') or 23500
+
+        # Makes sure partner_invoice_id', 'partner_shipping_id' and 'pricelist_id' are defined
+        if any(f not in vals for f in ['partner_invoice_id', 'partner_shipping_id', 'pricelist_id']):
+            partner = self.env['res.partner'].browse(vals.get('partner_id'))
+            addr = partner.address_get(['delivery', 'invoice'])
+            vals['partner_invoice_id'] = vals.setdefault(
+                'partner_invoice_id', addr['invoice'])
+            vals['partner_shipping_id'] = vals.setdefault(
+                'partner_shipping_id', addr['delivery'])
+            vals['pricelist_id'] = vals.setdefault(
+                'pricelist_id', partner.property_product_pricelist.id)
+        result = super(SaleOrder, self).create(vals)
+        return result
+
+    @api.depends('job_number_prefix', 'job_number_sufix', 'job_sequence')
+    def _compute_job_number(self):
+        for sale_order in self:
+            if not sale_order.job_sequence or sale_order.job_sequence == 0:
+                sale_order.job_sequence = self.env['ir.sequence'].next_by_code(
+                    'sale.order.job.number') or 23500
+            sale_order.job_number = str(sale_order.job_number_prefix) + str(
+                sale_order.job_sequence) + str(sale_order.job_number_sufix)

--- a/industrial_kiln/views/res_partner_views_inherit.xml
+++ b/industrial_kiln/views/res_partner_views_inherit.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <field name="vat" position="after">
                 <field name="plant_code" />
+                <field name="has_confirmed_SO" />
             </field>
         </field>
     </record>

--- a/industrial_kiln/views/res_partner_views_inherit.xml
+++ b/industrial_kiln/views/res_partner_views_inherit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record model="ir.ui.view" id="view_partner_form">
+        <field name="name">base.view.partner.form.inherit.industrial.kiln</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref='base.view_partner_form'/>
+        <field name="arch" type="xml">
+            <field name="vat" position="after">
+                <field name="plant_code" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/industrial_kiln/views/sale_order_views_inherit.xml
+++ b/industrial_kiln/views/sale_order_views_inherit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record model="ir.ui.view" id="view_order_form">
+        <field name="name">sale.view.order.form.inherit.industrial.kiln</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref='sale.view_order_form'/>
+        <field name="arch" type="xml">
+            <field name="payment_term_id" position="after">
+                <field name="job_number_prefix" />
+                <field name="job_sequence" />
+                <field name="job_number_sufix" />
+                <field name="job_number" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module creates a job number for every sales order. This field is composed of a prefix that the user chooses in a selection field;
a sequence that starts at 13500 and it automatically counts up; and a sufix that the user chooses in a selection field.
The user must be able to add values for both the prefix and the sufix using Studio.
The sequence is created using the ir.sequence model.

For the plant code, the field is added to the customer (res.partner) and is composed of two parts:
The first one is a prefix that consists of the first three non-special characters of the companys name. (Example: AT&T would have a prefix ATT).
The second part of the code is a sequence with a padding value of 5 and using this nomenclature: XXX-XX starting in 001-01.
An example of the complete code would be ATT001-01 and if there is another company that would have the prefix ATT, its code would be:
ATT001-02. This plant code is computed once the first Sale Order is confirmed for that customer.

The modules used in this task were sale_order and res_partner.

Both res_partner and sale order views were inherited to add the fields to those views.

Link to task: [#2874756](https://www.odoo.com/web#id=2874756&menu_id=4720&cids=17&action=333&active_id=4533&model=project.task&view_type=form)

### All Submissions:

* [ ] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [ ] I have used pre-commit
* [ ] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [ ] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [ ] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 
