### PR TITLE
[ADD] jobno-plantno: job number + plant number creation on save

### DIFF
--- a/jobno-plantno/__init__.py
+++ b/jobno-plantno/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/jobno-plantno/__manifest__.py
+++ b/jobno-plantno/__manifest__.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+{
+    'name': 'Job number / Plant Code',
+    'version': '15.0.0.1',
+    'category': 'sales',
+    'summary': 'Creator of job number/plant codes when filling out a new quotation.',
+    'description': """
+Job Number / Plant Code
+=======================
+Job Number / Plant Code fields for sales orders
+using sequencing numbers upon creation 
+of a quotation/sale order
+Author: yall
+task: 2874544
+    """,
+    'depends': [
+        'sale',
+    ],
+    'author': 'Odoo PS',
+    'data': [
+        'views/sale_order_view_inherit.xml',
+        'data/job_number_sequence.xml',
+        'data/plant_number_sequence.xml',
+    ],
+    'demo': [
+    ],
+    'license': 'OPL-1',
+}

--- a/jobno-plantno/data/job_number_sequence.xml
+++ b/jobno-plantno/data/job_number_sequence.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="job_number_sequence" model="ir.sequence">
+            <field name="name">Job number Sequence</field>
+            <field name="code">job.number.sequence</field>
+            <field name="padding">5</field>
+            <field name="number_next">13500</field>
+            <field name="number_increment">1</field>
+        </record>
+    </data>
+</odoo>

--- a/jobno-plantno/data/plant_number_sequence.xml
+++ b/jobno-plantno/data/plant_number_sequence.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="plant_number_sequence" model="ir.sequence">
+            <field name="name">Plant Number Sequence</field>
+            <field name="code">plant.number.sequence</field>
+            <field name="padding">5</field>
+            <field name="number_next">1</field>
+            <field name="number_increment">1</field>
+        </record>
+    </data>
+</odoo>

--- a/jobno-plantno/models/__init__.py
+++ b/jobno-plantno/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import sale_order

--- a/jobno-plantno/models/sale_order.py
+++ b/jobno-plantno/models/sale_order.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    job_prefix = fields.Selection(string='Job Prefix', selection=[('01', '01'), ('02', '02')])
+    job_suffix = fields.Selection(string='Job Suffix', selection=[('0b', '0b'), ('0a', '0a')])
+    job_number = fields.Char(string='Job Number', compute='_compute_job_number', store=True)
+
+    company_prefix = fields.Char(string='Company Prefix', compute='_compute_company_prefix')
+    plant_number = fields.Char(string='Plant Number', compute='_compute_plant_number', store=True)
+
+    @api.depends('job_prefix', 'job_suffix')
+    def _compute_job_number(self):
+        for so in self:
+            if not so.job_prefix or not so.job_suffix:
+                so.job_number = ''
+            else:
+                sequence = self.env['ir.sequence'].search([('code', '=', 'job.number.sequence')])
+                so.job_number = so.job_prefix + sequence.get_next_char(sequence.number_next_actual) + so.job_suffix
+
+    @api.depends('partner_id')
+    def _compute_company_prefix(self):
+        for so in self:
+            so.company_prefix = ''
+            if so.partner_id:
+                special_chars = '[ @_!#$%^&*()<>?/\|}{~:]'
+                char, char_count = 0, 0
+                while char_count < 3:
+                    if so.partner_id.name[char] not in special_chars:
+                        so.company_prefix += so.partner_id.name[char].upper()
+                        char_count += 1
+                    char += 1
+            else:
+                so.company_prefix = ''
+
+    @api.depends('company_prefix')
+    def _compute_plant_number(self):
+        for so in self:
+            if so.company_prefix:
+                sequence_plant = self.env['ir.sequence'].search([('code', '=', 'plant.number.sequence')])
+                plant_no = sequence_plant.get_next_char(sequence_plant.number_next_actual)
+                so.plant_number = so.company_prefix + plant_no[:3] + '-' + plant_no[2:]
+            else:
+                so.plant_number = ''
+
+    @api.model
+    def create(self, vals):
+        vals['job_number'] = vals.get('job_prefix') + self.env['ir.sequence'].next_by_code('job.number.sequence') + vals.get('job_suffix')
+        self.env['ir.sequence'].next_by_code('plant.number.sequence')
+        return super().create(vals)

--- a/jobno-plantno/views/sale_order_view_inherit.xml
+++ b/jobno-plantno/views/sale_order_view_inherit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sale_order_view_inherit" model="ir.ui.view">
+        <field name="name">sale.order.view.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"></field>
+        <field name="arch" type="xml">
+            <xpath expr="//form/sheet/group/group" position="after">
+                <group>
+                    <field name="job_prefix"/>
+                    <field name="job_suffix"/>
+                    <field name="job_number" attrs="{'readonly':True}"/>
+                    <field name="plant_number"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This implementation ensures that the plant numbers and job numbers are only incremented when clicking save. This is because we do not want to increment the counter if we discard the sale order.
This code also allows to add any customer names with special characters within their name.

### Description

In the Sale Order model, upon creation of a new record, it was required to create a **job number** and a **plant number** based on:
- Selection fields and a sequence number (for job number)
- Customer Company and a sequence number (for plant number)

This code creates the job number and plant number only when clicking the save button. It handles special characters if the customer company name has them.

Link to task: [#ID](https://www.odoo.com/web#model=project.task&id=2874544)

### All Submissions:

* [x] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [ ] I have used pre-commit
* [x] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [ ] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [ ] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 
