### PR TITLE
[ADD]odoo_generator: automatically generate job number, plant code

### DIFF
--- a/odoo_generator/__init__.py
+++ b/odoo_generator/__init__.py
@@ -1,0 +1,2 @@
+
+from . import models

--- a/odoo_generator/__manifest__.py
+++ b/odoo_generator/__manifest__.py
@@ -1,0 +1,17 @@
+
+{
+    'name': 'Odoo Generator',
+    'sumary': 'Industrial Kiln & Dryer Group : Job number, Plant code',
+    'description': """
+        odoo Generator helps to generate the job number and plant code.
+    """,
+    'author': 'Odoo PS',
+    'category': 'Sales',
+    'version': '14.0.1.0.0',
+    'depends': ['sale'],
+    'license': 'OPL-1',
+    'data': [
+        'views/sale_order_views_inherit.xml',
+        'views/res_partner_views_inherit.xml',
+    ],
+}

--- a/odoo_generator/models/__init__.py
+++ b/odoo_generator/models/__init__.py
@@ -1,0 +1,3 @@
+
+from . import sale_order
+from . import res_partner

--- a/odoo_generator/models/res_partner.py
+++ b/odoo_generator/models/res_partner.py
@@ -1,0 +1,46 @@
+import re
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError, ValidationError
+
+
+class ResPartner(models.Model):
+
+    _inherit = 'res.partner'
+
+    has_confirmed_SO = fields.Boolean(string='Has a confirmed SO.')
+    plant_code = fields.Char(string='Plant Code',
+                             compute='_compute_plant_code')
+    plant_prefix = fields.Char(string='Plant Prefix')
+
+    @api.depends('has_confirmed_SO')
+    def _compute_plant_code(self):
+        for partner in self:
+            if partner.has_confirmed_SO and not partner.plant_code:
+                sequence = self.env['ir.sequence'].create({
+                    'name': 'Secuence for Lot Number',
+                    'code': partner.plant_prefix,
+                    'prefix': partner.plant_prefix,
+                    'padding': 5,
+                    'implementation': 'standard',
+                    'number_next': 101,
+                    "number_increment": 1,
+                    "active": True,
+                }).next_by_code(partner.plant_prefix)
+                sequence = str(sequence)
+                partner.plant_code = sequence[0:6] + '-' + sequence[6:]
+            else:
+                partner.plant_code = False
+
+    def prepare_plant_prefix(self):
+        if self.is_company:
+            name = self.name
+        else:
+            if self.parent_id:
+                name = self.parent_id.name
+            else:
+                name = self.name
+        name = re.sub('[^A-Za-z0-9]+', '', name)
+        if len(name) >= 3:
+            self.plant_prefix = name.upper()[0:3]
+        else:
+            self.plant_prefix = name

--- a/odoo_generator/models/sale_order.py
+++ b/odoo_generator/models/sale_order.py
@@ -1,0 +1,82 @@
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError, ValidationError
+
+
+class SaleOrder(models.Model):
+
+    _inherit = 'sale.order'
+
+    job_number = fields.Text(
+        string='Job Number')
+
+    plant_code = fields.Text(string='Plant Code')
+
+    job_prefix = fields.Selection([('101', '101'),
+                                   ('201', '201'),
+                                   ('301', '301'),
+                                   ('401', '401'),
+                                   ('401', '401')],
+                                  'Job Prefix', copy=False, required=True, default='101',
+                                  help="Prefix of the job number.\n")
+
+    job_suffix = fields.Selection([('zac', 'ZAC'),
+                                   ('tyr', 'TYR'),
+                                   ('hec', 'HEC'),
+                                   ('edu', 'EDU'),
+                                   ('ale', 'ALE')],
+                                  'Job Suffix', copy=False, required=True, default='zac',
+                                  help="Suffix of the job number.\n")
+
+    # override the function create of the sale order to generate the job number
+    @api.model
+    def create(self, vals):
+        if vals.get('job_prefix') and vals.get('job_suffix'):
+            ir_sequence = self.env['ir.sequence']
+            vals['job_number'] = ir_sequence.next_by_code(
+                vals['job_prefix'] + vals['job_suffix'])
+            if not vals['job_number']:
+                vals['job_number'] = ir_sequence.create({
+                    'name': 'Job Number',
+                    'code': vals['job_prefix'] + vals['job_suffix'],
+                    'prefix': vals['job_prefix'],
+                    'suffix': vals['job_suffix'],
+                    'padding': 5,
+                    'number_next': 13500,
+                    'number_increment': 1,
+                    'implementation': 'standard',
+                }).next_by_code(vals['job_prefix'] + vals['job_suffix'])
+        return super().create(vals)
+
+     # override the function write of the sale order to generate the job number
+    def write(self, vals):
+        job_suffix = vals.get('job_suffix') if vals.get(
+            'job_suffix') else self.job_suffix
+        job_prefix = vals.get('job_prefix') if vals.get(
+            'job_prefix') else self.job_prefix
+        vals['job_number'] = self.job_number
+        if job_prefix and job_suffix:
+            ir_sequence = self.env['ir.sequence']
+            sequence = ir_sequence.search(
+                [('code', '=', job_prefix + job_suffix)])
+            if (not vals['job_number'] or not sequence):
+                vals['job_number'] = ir_sequence.create({
+                    'name': 'Job Number',
+                    'code': job_prefix + job_suffix,
+                    'prefix': job_prefix,
+                    'suffix': job_suffix,
+                    'padding': 5,
+                    'number_next': 13500,
+                    'number_increment': 1,
+                    'implementation': 'standard',
+                }).next_by_code(job_prefix + job_suffix)
+            else:
+                vals['job_number'] = sequence.next_by_code(
+                    job_prefix + job_suffix)
+        return super().write(vals)
+
+    def action_confirm(self):
+        res = super().action_confirm()
+        if not self.partner_id.has_confirmed_SO:
+            self.partner_id.prepare_plant_prefix()
+            self.partner_id.has_confirmed_SO = True
+        return res

--- a/odoo_generator/views/res_partner_views_inherit.xml
+++ b/odoo_generator/views/res_partner_views_inherit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record model="ir.ui.view" id="base_view_partner_form">
+        <field name="name">base.view.partner.form.inherit.generator</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <field name="type" position="after">
+                <field name="plant_code" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/odoo_generator/views/sale_order_views_inherit.xml
+++ b/odoo_generator/views/sale_order_views_inherit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <record model="ir.ui.view" id="sale_view_order_form">
+        <field name="name">sale.order.view.form.inherit.generator</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="job_prefix" />
+                <field name="job_suffix" />
+                <field name="job_number" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
### Description
        -inherit from sale_order and override create and write to generate de job number
	-inherit from res_partner and generate the plant code only when confirmming the first sales order
	-inherit the sale_order view form to add the prefix and suffix option and show de job_number when generated
	-inherit the res_partner view form and show the plant code once is generated


Link to task: [#2874720](https://www.odoo.com/web#id=2874720&cids=17&menu_id=4720&action=4665&active_id=2874696&model=project.task&view_type=form)


