### PR TITLE
[ADD] industrial_kiln: Added module to generate job number in sale or…

### DIFF
--- a/industrial_kiln/__init__.py
+++ b/industrial_kiln/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/industrial_kiln/__manifest__.py
+++ b/industrial_kiln/__manifest__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Industrial Kiln and Dryer Group',
+    'sumary': '',
+    'description': """
+        Module to
+    """,
+    'author': 'Odoo PS',
+    'category': 'Sales',
+    'version': '14.0.1.0.0',
+    'depends': [
+        'sale',
+    ],
+    'data': [
+        'views/sale_order_views_inherit.xml',
+        'views/res_partner_views_inherit.xml',
+    ],
+    'license': 'OPL-1',
+}

--- a/industrial_kiln/models/__init__.py
+++ b/industrial_kiln/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order,res_partner

--- a/industrial_kiln/models/res_partner.py
+++ b/industrial_kiln/models/res_partner.py
@@ -1,0 +1,31 @@
+from odoo import models, fields, api
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+    plant_code = fields.Char(string='Plant Code', readonly=True)
+
+    def _get_plant_code(self):
+        for partner in self:
+            if partner.plant_code:
+                pass
+            elif(partner.commercial_company_name):
+                prefix = ''.join(
+                    filter(str.isalnum, partner.commercial_company_name)).upper()[:3]
+                sequence = self.env['ir.sequence'].next_by_code(prefix)
+                if not (sequence):
+                    sequence = self.env['ir.sequence'].create({
+                        'name': 'Secuence for Plant Code',
+                        'code': prefix,
+                        'prefix': prefix,
+                        'suffix': '',
+                        'padding': 5,
+                        'implementation': 'standard',
+                        'number_next': 1,
+                        "number_increment": 1,
+                        "active": True,
+                    }).next_by_code(prefix)
+                sequence = str(sequence[:6]) + '-' + str(sequence[6:])
+                partner.plant_code = sequence
+            else:
+                partner.plant_code = False

--- a/industrial_kiln/models/sale_order.py
+++ b/industrial_kiln/models/sale_order.py
@@ -1,0 +1,62 @@
+from odoo import models, fields, api
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    job_number = fields.Text(
+        string="Job Number", required=True, default='000000')
+
+    @api.model_create_multi
+    def create(self, vals_list):
+
+        vals_list[0] = self._update_job_number(vals_list[0])
+
+        return super().create(vals_list)
+
+    def write(self, values):
+        values = self._update_job_number(values)
+        result = super().write(values)
+        return result
+
+    def _update_job_number(self, vals):
+
+        new_code = (vals.get('x_studio_prefix') or self.x_studio_prefix) + \
+            (vals.get('x_studio_suffix') or self.x_studio_suffix)
+        vals.update(job_number=(self.generate_sequence(
+            {
+                'name': 'Job Number',
+                'code': new_code,
+                'prefix': vals.get('x_studio_prefix') or self.x_studio_prefix,
+                'suffix': vals.get('x_studio_suffix') or self.x_studio_suffix,
+                'padding': 5,
+                'number_increment': 1,
+                'number_next': 13500,
+                'implementation': 'standard'
+            }
+        )))
+        return vals
+
+    def action_confirm(self):
+        res = super().action_confirm()
+        if not (self.partner_id.plant_code):
+            self.partner_id._get_plant_code()
+        return res
+
+    def generate_sequence(self, vals):
+        ir_sequence_ref = self.env['ir.sequence']
+        sequence_number = ir_sequence_ref.next_by_code(
+            vals['code'])
+        if not sequence_number:
+            sequence_number = ir_sequence_ref.create({
+                'name': vals['name'],
+                'code': vals['code'],
+                'prefix': vals['prefix'],
+                'suffix': vals['suffix'],
+                'padding': vals['padding'],
+                'number_increment': vals['number_increment'],
+                'number_next': vals['number_next'],
+                'implementation': vals['implementation'],
+            }).next_by_code(vals['code'])
+
+        return sequence_number

--- a/industrial_kiln/views/res_partner_views_inherit.xml
+++ b/industrial_kiln/views/res_partner_views_inherit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_partner_view_form_inherit" model="ir.ui.view">
+        <field name="name">res.partner.view.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <field name="vat" position="after">
+                <field name="plant_code"></field>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/industrial_kiln/views/sale_order_views_inherit.xml
+++ b/industrial_kiln/views/sale_order_views_inherit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sale_order_form_view_inherit" model="ir.ui.view">
+        <field name="name">sale.order.form.view.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <field name="partner_shipping_id" position="after">
+                <field name="job_number"></field>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Added a module for generating a Job number with a prefix and suffix starting in 13500 for sales orders. The user must select (from selection fields) the prefix and suffix in the sales order form view. This job number will be generated from the ir.sequence module.
When the user confirms the order, the module will generate a plant code that will be stored in the res.partner model.

Link to task: https://www.odoo.com/web#id=2874579&cids=17&model=project.task&view_type=form&menu_id=4720
