### PR TITLE
[IMP] New York P&W: Automated product name & UPC

### DIFF
--- a/new_york_pw/__init__.py
+++ b/new_york_pw/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/new_york_pw/__manifest__.py
+++ b/new_york_pw/__manifest__.py
@@ -1,0 +1,29 @@
+{
+  'name':'New York P&W',
+
+  'summary':'''Automated product name & UPC''',
+  
+  'description':'''
+   The customer generates product names when he orders new products from the suppliers.
+   The product name is a code and is linked to the product category (names must be unique).
+   The customer also needs to generate UPC automatically. He generates UPC and then sends 
+   it back to its manufacturer who will print it on the labels. 
+  ''',
+
+  'author':'Odoo',
+
+  'website':'https://www.odoo.com',
+
+  'category':'Training',
+
+  'version':'14.0.1.0.0',
+
+  'depends':['product'],
+  
+  'data':[
+    'views/product_category_inherit.xml',
+    'views/product_form_inherit.xml'
+  ],
+
+  'license': 'OPL-1'
+}

--- a/new_york_pw/models/__init__.py
+++ b/new_york_pw/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_template
+from . import product_category

--- a/new_york_pw/models/product_category.py
+++ b/new_york_pw/models/product_category.py
@@ -1,0 +1,21 @@
+from odoo import fields, models
+
+
+class ProductCategory(models.Model):
+  _inherit = 'product.category'
+
+  def _default_sequence_id(self):
+    res = self.env['ir.sequence'].search([('code', '=', 'nypw_seq')])
+    if not res:
+      res = self.env['ir.sequence'].create({
+        'code': 'nypw_seq',
+        'name': 'NY P&W Sequence',
+        'prefix': 'NYPW',
+        'padding': 6,
+    })
+    return res
+
+  sequence_id = fields.Many2one('ir.sequence',
+                string='Internal Sequence',
+                required=True,
+                default=_default_sequence_id)

--- a/new_york_pw/models/product_template.py
+++ b/new_york_pw/models/product_template.py
@@ -1,0 +1,52 @@
+from odoo import api,fields, models
+
+
+class ProductTemplate(models.Model):
+  _inherit = 'product.template'
+
+  product_gender = fields.Selection([
+        ('red', 'Red'),
+        ('black', 'Black'),
+        ('yellow', 'Yellow'),
+        ('white', 'White'),
+        ('green', 'Green')
+    ], required=True, default='red')
+
+  upc = fields.Many2one('ir.sequence', compute='_compute_upc')
+
+  barcode = fields.Char(compute='_compute_barcode', store=True)
+
+  @api.model
+  def create(self, values):
+    if isinstance(values, list):
+      for value in values:
+        self._assign_name(value)
+    else:
+      self._assign_name(values)
+    return super().create(values)
+
+  @api.model
+  def _assign_name(self, value: dict):
+    if not value.get('name') and value.get('categ_id'):
+      value['name'] = self.env['ir.sequence'].browse(value['categ_id']).next_by_id()
+
+  @api.depends('product_gender')
+  def _compute_upc(self):
+    for record in self:
+      prefix = record.product_gender[:3].upper()
+      seq = self.env['ir.sequence'].search([('code', '=', prefix)])
+      if not seq:
+        seq = self.env['ir.sequence'].create({
+              'code': prefix,
+              'name': record.product_gender,
+              'prefix': prefix,
+              'padding': 3
+      })
+      record.upc = seq
+
+  @api.depends('upc')
+  def _compute_barcode(self):
+    for record in self:
+      if record.upc:
+        record.barcode = record.upc.next_by_id()
+        

--- a/new_york_pw/views/product_category_inherit.xml
+++ b/new_york_pw/views/product_category_inherit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <record id="product_category_view_form" model="ir.ui.view">
+    <field name="name">product.category.form.inherit</field>
+    <field name="model">product.category</field>
+    <field name="inherit_id" ref="product.product_category_form_view"/>
+    <field name="arch" type="xml">
+      <sheet>
+        <group string="Name Generation">
+          <field name="sequence_id"/>
+        </group>
+      </sheet>
+    </field>
+  </record>
+</odoo>

--- a/new_york_pw/views/product_form_inherit.xml
+++ b/new_york_pw/views/product_form_inherit.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo>
+  <record id='product_template_only_view_form' model='ir.ui.view'>
+    <field name='name'>product.template.view.form.inherit</field>
+    <field name='model'>product.template</field>
+    <field name='inherit_id' ref='product.product_template_only_form_view'/>
+    <field name='arch' type='xml'>
+
+      <field name="name" position="attributes">
+        <attribute name="attrs">{'required':[('categ_id','=',False)]}</attribute>
+        <attribute name="placeholder">Auto-generated</attribute>
+      </field>
+
+      <field name="barcode" position="after">
+        <field name="product_gender"/>
+      </field>
+      
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
### Description

The customer generates product names when he orders new products from the suppliers.
The product name is a code and is linked to the product category (names must be unique).
The customer also needs to generate UPC automatically. He generates UPC and then sends it back to its manufacturer who will print it on the labels.

Link to task: [2874495](https://www.odoo.com/web#id=2874495&cids=17&menu_id=4720&action=4665&active_id=2874485&model=project.task&view_type=form)