### PR TITLE
[IMP] code_survey: safe_compile module for safe(r) untrusted code exec

### DIFF
--- a/code_survey/__init__.py
+++ b/code_survey/__init__.py
@@ -1,3 +1,3 @@
 from . import models
 from . import controllers
-
+from . import tools

--- a/code_survey/controllers/main.py
+++ b/code_survey/controllers/main.py
@@ -6,7 +6,6 @@ from odoo.http import request
 from odoo.addons.survey.controllers.main import Survey  
 
 
-
 class SurveyInherit(Survey):
    
     @http.route('/survey/submit/<string:survey_token>/<string:answer_token>', type='json', auth='public', website=True)

--- a/code_survey/models/survey_question_argument.py
+++ b/code_survey/models/survey_question_argument.py
@@ -1,5 +1,6 @@
 from odoo import api, fields, models
 
+
 class SurveyQuestionArgument(models.Model):
     _name = 'survey.question_argument'
 

--- a/code_survey/models/survey_question_test.py
+++ b/code_survey/models/survey_question_test.py
@@ -1,4 +1,4 @@
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class SurveyQuestionTest(models.Model):


### PR DESCRIPTION
### Description

This commit contains the code that handles the untrusted code execution from the user in the extended survey module.

Basically, the code relies on the existing safe_eval module, but adds some necessary features (such as importing modules and classes) for code evaluation and testing.
The class that wraps the candidate's solution is built at runtime, and cherry-picked from the code object provided by the compile() function

Also added some code formatting corrections.

Link to task: [#ID](https://www.odoo.com/web#model=project.task&id=2856501)

### All Submissions:

* [x] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [x] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
* [ ] I have used pre-commit
* [ ] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [ ] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [ ] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 
